### PR TITLE
Renaming wandb test project to statiobench

### DIFF
--- a/stationbench/compare_forecasts.py
+++ b/stationbench/compare_forecasts.py
@@ -380,7 +380,7 @@ if __name__ == "__main__":
     evaluation_benchmarks = xr.open_zarr(args.evaluation_benchmarks_loc)
     reference_benchmark_locs = ast.literal_eval(args.reference_benchmark_locs)
 
-    wandb_run = wandb.init(id=args.run_name, project="test")
+    wandb_run = wandb.init(id=args.run_name, project="stationbench")
     if wandb_run is None:
         raise RuntimeError("Failed to initialize wandb run")
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and which issue is fixed. -->
- previously all projects would be named `test` on wandb
- now they name is stationbench
- quick fix of #2 (can think about a more customizable solution later)

Changes made:
- rename test to stationbench

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have run `poetry exec format` to format my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [x] All new and existing tests passed