### PR TITLE
Add point forecast

### DIFF
--- a/stationbench/calculate_metrics.py
+++ b/stationbench/calculate_metrics.py
@@ -3,13 +3,14 @@ import logging
 from datetime import date, datetime
 from typing import Union
 
+import numpy as np
 import xarray as xr
 from dask.distributed import Client, LocalCluster
 
-from stationbench.utils.regions import region_dict, select_region_for_stations
-from stationbench.utils.logging import init_logging
 from stationbench.utils.io import load_dataset
+from stationbench.utils.logging import init_logging
 from stationbench.utils.metrics import AVAILABLE_METRICS
+from stationbench.utils.regions import region_dict, select_region_for_stations
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +83,7 @@ def prepare_forecast(
             "longitude": "auto",
         },
     )
+    is_point_based = "station_id" in forecast.dims
 
     # First handle time dimensions
     forecast = forecast.sel(time=slice(start_date, end_date))
@@ -112,7 +114,10 @@ def prepare_forecast(
         forecast = forecast.sortby("longitude")
 
     # Select region
-    forecast = forecast.sel(latitude=lat_slice, longitude=lon_slice)
+    if is_point_based:
+        forecast = select_region_for_stations(forecast, lat_slice, lon_slice)
+    else:
+        forecast = forecast.sel(latitude=lat_slice, longitude=lon_slice)
 
     # Rename variables
     if wind_speed_name:
@@ -140,12 +145,42 @@ def prepare_forecast(
 def interpolate_to_stations(forecast: xr.Dataset, stations: xr.Dataset) -> xr.Dataset:
     """Interpolate forecast to station locations."""
     logger.info("Interpolating forecast to station locations")
-    forecast_interp = forecast.interp(
-        latitude=stations.latitude,
-        longitude=stations.longitude,
-        method="linear",
-    )
-    return forecast_interp
+
+    is_point_based = "station_id" in forecast.dims
+
+    if is_point_based:
+        logger.info("Detected point-based forecast format, no interpolation needed")
+        forecast_stations = forecast.station_id.values
+        stations_ids = stations.station_id.values
+        common_stations = np.intersect1d(forecast_stations, stations_ids)
+
+        if len(common_stations) == 0:
+            raise ValueError("No common stations found between forecast and stations")
+
+        logger.info("Found %d common stations", len(common_stations))
+
+        forecast = forecast.sel(station_id=common_stations)
+        stations_subset = stations.sel(station_id=common_stations)
+
+        # Validate coordinates match within tolerance
+        coord_tolerance = 0.01  # ~1km at equator
+        lat_diff = np.abs(forecast.latitude.values - stations_subset.latitude.values)
+        lon_diff = np.abs(forecast.longitude.values - stations_subset.longitude.values)
+
+        if np.any(lat_diff > coord_tolerance) or np.any(lon_diff > coord_tolerance):
+            raise ValueError(
+                f"Coordinate mismatch between forecast and stations exceeds tolerance of {coord_tolerance} degrees"
+            )
+
+        return forecast
+    else:
+        # Grid-based forecast - interpolate to station points
+        forecast_interp = forecast.interp(
+            latitude=stations.latitude,
+            longitude=stations.longitude,
+            method="linear",
+        )
+        return forecast_interp
 
 
 def generate_benchmarks(


### PR DESCRIPTION
## Description

This PR adds the ability to handle point-based forecasts.

Changes made:
`if is_point_based`:
- Select region differently
- Do not interpolate between grid but instead select the common stations by ID

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run `poetry exec format` to format my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [not needed imo] I have updated the documentation accordingly
- [x] All new and existing tests passed