### PR TITLE
Switch to opendata.jua.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Stationbench comes with ready-to-use weather stations from around the world. The
 
 Source: [Meteostat](https://dev.meteostat.net/) ([CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/legalcode))
 
-The benchmarking data can be accessed from `https://opendata.jua.sh/stationbench/meteostat_benchmark.zarr`.
+The benchmarking data can be accessed from `https://opendata.jua.ai/stationbench/meteostat_benchmark.zarr`.
 
-![Map of weather stations used for benchmarking](https://opendata.jua.sh/stationbench/stations_2023_map.png)
+![Map of weather stations used for benchmarking](https://opendata.jua.ai/stationbench/stations_2023_map.png)
 
-![Number of stations reporting over time](https://opendata.jua.sh/stationbench/stations_2018-2024.png)
+![Number of stations reporting over time](https://opendata.jua.ai/stationbench/stations_2018-2024.png)
 
 Besides the provided benchmarking data, you can also use your own ground truth data. The ground truth data must be in zarr format and must include the following dimensions and coordinates:
 - Must include dimensions: station_id, time
@@ -61,7 +61,7 @@ This script computes metrics by comparing forecast data against ground truth dat
 
 #### Options
 - `--forecast`: Location of the forecast data (required)
-- `--stations`: Location of the ground truth data (defaults to https://opendata.jua.sh/stationbench/meteostat_benchmark.zarr)
+- `--stations`: Location of the ground truth data (defaults to https://opendata.jua.ai/stationbench/meteostat_benchmark.zarr)
 - `--start_date`: Start date for benchmarking (required)
 - `--end_date`: End date for benchmarking (required)
 - `--output`: Output path for benchmarks (required)

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -1548,7 +1548,7 @@
    ],
    "source": [
     "rng = np.random.default_rng(seed=42)  # Create a random number generator instance\n",
-    "stations = xr.open_zarr(\"https://opendata.jua.sh/stationbench/meteostat_benchmark.zarr\", decode_timedelta=True)\n",
+    "stations = xr.open_zarr(\"https://opendata.jua.ai/stationbench/meteostat_benchmark.zarr\", decode_timedelta=True)\n",
     "stations_subset = stations.isel(station_id=rng.choice(stations.station_id.size, 1000, replace=False))\n",
     "stations_subset"
    ]

--- a/stationbench/__init__.py
+++ b/stationbench/__init__.py
@@ -13,7 +13,7 @@ def calculate_metrics(
     forecast: Union[str, xr.Dataset],
     stations: Union[
         str, xr.Dataset
-    ] = "https://opendata.jua.sh/stationbench/meteostat_benchmark.zarr",
+    ] = "https://opendata.jua.ai/stationbench/meteostat_benchmark.zarr",
     start_date: Union[str, datetime] = None,
     end_date: Union[str, datetime] = None,
     output: Optional[str] = None,

--- a/stationbench/calculate_metrics.py
+++ b/stationbench/calculate_metrics.py
@@ -235,7 +235,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--stations",
         type=str,
-        default="https://opendata.jua.sh/stationbench/meteostat_benchmark.zarr",
+        default="https://opendata.jua.ai/stationbench/meteostat_benchmark.zarr",
         help="Path to ground truth zarr dataset",
     )
     parser.add_argument(


### PR DESCRIPTION
Switching all mentions of `opendata.jua.sh` to `opendata.jua.ai` where we will store open data going forward.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist

- [x] I have run `poetry exec format` to format my code
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed